### PR TITLE
add Print and Fatal series logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,28 @@ go get github.com/taknb2nch/harelog
 
 ## Usage
 
+### Standard Logging (`Print`, `Fatal` series)
+For compatibility with the standard `log` package, `Print` and `Fatal` families of methods are provided.
+- `Print` methods log at the `INFO` level.
+- `Fatal` methods log at the `CRITICAL` level and then call os.Exit(1).
+
+```go
+import "github.com/taknb2nch/harelog"
+
+harelog.Println("Server is starting...")
+
+if err != nil {
+    harelog.Fatalf("Failed to initialize database: %v", err)
+}
+```
+
+**Example output:**
+```json
+{"message":"Server is starting...\\n","severity":"INFO","timestamp":"..."}
+{"message":"Failed to initialize database: ...","severity":"CRITICAL","timestamp":"..."}
+```
+If `Fatalf` is called, after printing the above log, the program will exit with status code 1.
+
 ### Formatted Logging (`...f` series)
 
 Outputs simple logs using a `printf`-style format.


### PR DESCRIPTION
## 概要

Goの標準`log`パッケージとの互換性を高め、利用者がより直感的に使えるようにするため、`Print`系および`Fatal`系のメソッドを追加しました。
これにより、既存のコードベースから`harelog`への移行がよりスムーズになることを目指します。

## 変更内容

- **`Print`系メソッドの実装:**
  - `Print`, `Printf`, `Println`を追加しました。
  - これらのメソッドは内部的に`INFO`レベルでログを記録します。
- **`Fatal`系メソッドの実装:**
  - `Fatal`, `Fatalf`, `Fatalln`を追加しました。
  - これらのメソッドは`CRITICAL`レベルでログを記録した後、`os.Exit(1)`を呼び出してプログラムを終了させます。
- **テストの追加:**
  - 新しく追加した全メソッドに対するユニットテストを実装しました。
  - `os.Exit`をテスト可能にするため、パッケージレベルの`osExit`変数を経由する一般的なテクニックを採用しています。
- **ドキュメントの更新:**
  - `README.md`に、新しいメソッドの使い方に関するセクションを追加しました。

## レビュー依頼

- 標準`log`パッケージの挙動と齟齬がないか、ご確認いただけると幸いです。
- 特に`os.Exit`のテスト方法について、より良いアプローチがあればご意見ください。

Closes #3 