### PR TITLE
Formatter機能を追加

### DIFF
--- a/formatter.go
+++ b/formatter.go
@@ -1,0 +1,127 @@
+package harelog
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Formatter is an interface for converting a logEntry into a byte slice.
+type Formatter interface {
+	Format(entry *logEntry) ([]byte, error)
+}
+
+// jsonFormatter formats log entries as JSON.
+type jsonFormatter struct{}
+
+// NewJSONFormatter creates a new JSONFormatter.
+func NewJSONFormatter() *jsonFormatter {
+	return &jsonFormatter{}
+}
+
+// Format converts a logEntry to JSON format.
+func (f *jsonFormatter) Format(e *logEntry) ([]byte, error) {
+	m := make(map[string]interface{})
+
+	for k, v := range e.Payload {
+		m[k] = v
+	}
+
+	m["message"] = e.Message
+	m["severity"] = e.Severity
+
+	if e.Trace != "" {
+		m["logging.googleapis.com/trace"] = e.Trace
+	}
+
+	if e.SpanID != "" {
+		m["logging.googleapis.com/spanId"] = e.SpanID
+	}
+
+	if e.TraceSampled != nil {
+		m["logging.googleapis.com/trace_sampled"] = e.TraceSampled
+	}
+
+	if e.HTTPRequest != nil {
+		m["httpRequest"] = e.HTTPRequest
+	}
+
+	if e.SourceLocation != nil {
+		m["logging.googleapis.com/sourceLocation"] = e.SourceLocation
+	}
+
+	m["timestamp"] = e.Time
+
+	if len(e.Labels) > 0 {
+		m["labels"] = e.Labels
+	}
+
+	if e.CorrelationID != "" {
+		m["correlationId"] = e.CorrelationID
+	}
+
+	return json.Marshal(m)
+}
+
+// textFormatter formats log entries as human-readable text.
+type textFormatter struct{}
+
+// NewTextFormatter creates a new TextFormatter.
+func NewTextFormatter() *textFormatter {
+	return &textFormatter{}
+}
+
+// Format converts a logEntry to a single-line text format.
+func (f *textFormatter) Format(e *logEntry) ([]byte, error) {
+	var b bytes.Buffer
+
+	// Timestamp
+	b.WriteString(e.Time.Format(time.RFC3339))
+	b.WriteString(" ")
+
+	// Severity
+	b.WriteString("[")
+	b.WriteString(e.Severity)
+	b.WriteString("] ")
+
+	// Message
+	b.WriteString(strings.TrimRight(e.Message, "\n"))
+
+	// Add payload only if it exists.
+	if len(e.Payload) > 0 {
+		b.WriteString(" {")
+
+		keys := make([]string, 0, len(e.Payload))
+
+		for k := range e.Payload {
+			keys = append(keys, k)
+		}
+
+		sort.Strings(keys)
+
+		for i, k := range keys {
+			if i > 0 {
+				b.WriteString(", ")
+			}
+
+			b.WriteString(k)
+			b.WriteString("=")
+
+			// Handle strings and other types differently for quoting.
+			val := e.Payload[k]
+
+			if s, ok := val.(string); ok {
+				b.WriteString(fmt.Sprintf("%q", s))
+			} else {
+				b.WriteString(fmt.Sprint(val))
+			}
+		}
+
+		b.WriteString("}")
+	}
+
+	return b.Bytes(), nil
+}

--- a/formatter_test.go
+++ b/formatter_test.go
@@ -1,0 +1,100 @@
+package harelog
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestJSONFormatter_Format directly tests the output of the jsonFormatter.
+func TestJSONFormatter_Format(t *testing.T) {
+	f := NewJSONFormatter()
+	testTime := time.Date(2025, 9, 25, 12, 0, 0, 0, time.UTC)
+
+	entry := &logEntry{
+		Message:  "json format test",
+		Severity: string(LogLevelInfo),
+		Time:     jsonTime{testTime},
+		Payload: map[string]interface{}{
+			"user": "gopher",
+		},
+	}
+
+	b, err := f.Format(entry)
+	if err != nil {
+		t.Fatalf("Format() returned an error: %v", err)
+	}
+
+	// Basic checks for JSON validity and content
+	s := string(b)
+	if !strings.Contains(s, `"message":"json format test"`) {
+		t.Errorf("output missing message: %s", s)
+	}
+	if !strings.Contains(s, `"severity":"INFO"`) {
+		t.Errorf("output missing severity: %s", s)
+	}
+	if !strings.Contains(s, `"user":"gopher"`) {
+		t.Errorf("output missing payload: %s", s)
+	}
+	if !strings.Contains(s, `"timestamp":"2025-09-25T12:00:00Z"`) {
+		t.Errorf("output missing or incorrect timestamp: %s", s)
+	}
+}
+
+// TestTextFormatter_Format directly tests the various outputs of the textFormatter.
+func TestTextFormatter_Format(t *testing.T) {
+	f := NewTextFormatter()
+	testTime := time.Date(2025, 9, 25, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name     string
+		entry    *logEntry
+		expected string
+	}{
+		{
+			name: "Simple message with no payload",
+			entry: &logEntry{
+				Message:  "server started",
+				Severity: string(LogLevelInfo),
+				Time:     jsonTime{testTime},
+			},
+			expected: `2025-09-25T12:00:00Z [INFO] server started`,
+		},
+		{
+			name: "Message with payload",
+			entry: &logEntry{
+				Message:  "request failed",
+				Severity: string(LogLevelError),
+				Time:     jsonTime{testTime},
+				Payload: map[string]interface{}{
+					"status": 500,
+					"path":   "/api/v1/users",
+				},
+			},
+			expected: `2025-09-25T12:00:00Z [ERROR] request failed {path="/api/v1/users", status=500}`,
+		},
+		{
+			name: "Println message with trailing newline",
+			entry: &logEntry{
+				Message:  "processing item\n",
+				Severity: string(LogLevelDebug),
+				Time:     jsonTime{testTime},
+			},
+			expected: `2025-09-25T12:00:00Z [DEBUG] processing item`,
+		},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+		t.Run(tc.name, func(t *testing.T) {
+			b, err := f.Format(tc.entry)
+			if err != nil {
+				t.Fatalf("Format() returned an error: %v", err)
+			}
+			got := string(b)
+			if got != tc.expected {
+				t.Errorf("unexpected text output:\ngot:  %s\nwant: %s", got, tc.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 概要

ローカルでの開発体験を向上させるため、ログの出力形式をカスタマイズできる**Formatter**機能を導入しました。
これにより、従来のJSON形式に加え、人間が読みやすい一行のテキスト形式でのログ出力が可能になります。

## 変更内容

- **`Formatter`インターフェースの導入:**
  - ログエントリを出力形式に変換する責務を持つ`Formatter`インターフェースを新しく定義しました。
  - 関連するコードは、新しく作成した`formatter.go`に分離しました。

- **具象Formatterの実装:**
  - **`JSONFormatter`**: 従来のJSON出力ロジックを、この新しいFormatterにリファクタリングしました。後方互換性のため、これがデフォルトのフォーマッタとなります。
  - **`TextFormatter`**: 開発中のコンソールでの視認性を高めるため、`タイムスタンプ [LEVEL] メッセージ {key="value"}`形式のテキストフォーマッタを新しく実装しました。

- **関数型オプションパターンの導入:**
  - `New()`関数で、`WithFormatter(f Formatter)`や`WithOutput(w io.Writer)`といったオプションを渡して、ロガーを柔軟に設定できるようにしました。
  - これにより、APIの拡張性が向上しました。

- **`(*Logger).With...`メソッドの維持:**
  - `New()`での初期設定とは別に、既存のロガーインスタンスから出力先などが異なる派生ロガーを生成するための`(*Logger).WithOutput`等のメソッドは、その役割を維持したまま残しています。

- **テストの追加・更新:**
  - `formatter_test.go`を新設し、各フォーマッタの出力を直接テストするようにしました。
  - `harelog_test.go`では、`WithFormatter`オプションが正しく機能することを確認するテストを追加しました。

## レビュー依頼

- 関数型オプション (`New(With...)`) と派生用メソッド (`logger.With...`) の共存というAPI設計に問題がないか、ご確認いただけると幸いです。
- 新しい`TextFormatter`の出力形式について、より良い改善案があればご意見ください。

Close #4 