### PR TITLE
 fix: デフォルトロガーのフォーマッタを変更可能にする

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -479,7 +479,21 @@ func (l *Logger) WithLogLevel(level logLevel) *Logger {
 // WithOutput returns a new logger instance that writes to the provided io.Writer.
 func (l *Logger) WithOutput(w io.Writer) *Logger {
 	newLogger := l.Clone()
-	newLogger.out = w
+
+	if w != nil {
+		newLogger.out = w
+	}
+
+	return newLogger
+}
+
+// WithFormatter returns a new logger instance with the specified formatter.
+func (l *Logger) WithFormatter(f Formatter) *Logger {
+	newLogger := l.Clone()
+
+	if f != nil {
+		newLogger.formatter = f
+	}
 
 	return newLogger
 }
@@ -547,6 +561,14 @@ func SetDefaultOutput(w io.Writer) {
 	defer stdMutex.Unlock()
 
 	std = std.WithOutput(w)
+}
+
+// SetDefaultFormatter sets the formatter for the default logger.
+func SetDefaultFormatter(f Formatter) {
+	stdMutex.Lock()
+	defer stdMutex.Unlock()
+
+	std = std.WithFormatter(f)
 }
 
 // SetDefaultLogLevel sets the log level for the default logger.
@@ -788,7 +810,9 @@ type Option func(*Logger)
 // WithFormatter sets the formatter for the logger.
 func WithFormatter(f Formatter) Option {
 	return func(l *Logger) {
-		l.formatter = f
+		if f != nil {
+			l.formatter = f
+		}
 	}
 }
 


### PR DESCRIPTION
### 概要

現状のAPIでは、`New(WithFormatter(...))` を使ってカスタムフォーマッタを持つ新しいロガーインスタンスを作成することはできますが、パッケージレベルのデフォルトロガー (`std`) が使用するフォーマッタを変更する手段がありませんでした。

これにより、`harelog.Infof` などのパッケージレベル関数は常にJSON形式で出力されてしまい、特に開発環境でアプリケーション全体のログ形式をテキストに切り替えたい、といった場合に柔軟性を欠いていました。

このPull Requestは、このAPIの抜け漏れを修正し、デフォルトロガーのフォーマッタを設定可能にすることで、ライブラリの使い勝手を向上させます。

### 変更内容

- **`SetDefaultFormatter(f Formatter)` 関数の追加:**
  - `SetDefaultOutput` や `SetDefaultLogLevel` と一貫性を保つため、パッケージレベルのデフォルトロガーが使用するフォーマッタを設定するための関数を新しく追加しました。

- **`(*Logger).WithFormatter(f Formatter) *Logger` メソッドの追加:**
  - `(*Logger).WithOutput` とのAPIの一貫性を保ち、既存のロガーインスタンスからフォーマッタだけが異なる派生ロガーを生成できるようにするため、このメソッドを追加しました。

- **テストの更新:**
  - `TestDefaultLogger`をリファクタリングし、`SetDefaultFormatter`が正しくデフォルトロガーの出力形式を変更することを検証するテストケースを追加しました。

### レビュー依頼

- APIの設計に問題がないか、特に `SetDefault...` (グローバル設定) と `logger.With...` (派生インスタンス生成) の役割分担が明確になっているか、ご確認いただけると幸いです。

Closes #9
