### PR TITLE
feat: 構造化ロギングのためのFatalwメソッドを追加

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -325,6 +325,18 @@ func (l *Logger) Criticalw(msg string, kvs ...interface{}) {
 	l.print(l.createEntryw(LogLevelCritical, msg, kvs...))
 }
 
+// Fatalw logs a message with structured key-value pairs at the Critical level
+// and then calls os.Exit(1).
+func (l *Logger) Fatalw(msg string, kvs ...interface{}) {
+	if !l.IsCriticalEnabled() {
+		return
+	}
+
+	l.print(l.createEntryw(LogLevelCritical, msg, kvs...))
+
+	osExit(1)
+}
+
 // createEntry creates a logEntry with a pre-formatted message.
 func (l *Logger) createEntry(level logLevel, msg string) *logEntry {
 	return &logEntry{
@@ -758,6 +770,15 @@ func Criticalw(msg string, kvs ...interface{}) {
 	defer stdMutex.RUnlock()
 
 	std.Criticalw(msg, kvs...)
+}
+
+// Fatalw logs a message with structured key-value pairs at the Critical level
+// using the default logger and then calls os.Exit(1).
+func Fatalw(msg string, kvs ...interface{}) {
+	stdMutex.RLock()
+	defer stdMutex.RUnlock()
+
+	std.Fatalw(msg, kvs...)
 }
 
 // isDebugEnabled returns


### PR DESCRIPTION
### 概要

`Criticalw`を呼び出した直後にプログラムを終了させる、という一般的なユースケースに対応するため、構造化ロギング版の`Fatal`メソッドである`Fatalw`を新しく追加しました。

これにより、`Fatal`系のメソッドが`...f`（フォーマット指定）と`...w`（構造化）の両方に対応することになり、APIの一貫性が向上します。

### 変更内容

- **`Fatalw`メソッドの実装:**
  - `*Logger`に`Fatalw(msg string, kvs ...interface{})`メソッドを追加しました。
  - 内部では`Criticalw`を呼び出した後、`osExit(1)`でプログラムを終了させます。

- **パッケージレベル関数の実装:**
  - デフォルトロガーから呼び出すための、パッケージレベル関数`Fatalw`を追加しました。

- **テストの追加:**
  - 新しい`TestFatalwMethod`テストを追加し、`Fatalw`が正しい構造化ログを出力し、かつプログラムを終了しようとすることを検証するようにしました。

### レビュー依頼

- 実装内容に問題がないか、ご確認をお願いします。
- APIの一貫性が向上しているか、という観点でもご意見いただけると幸いです。

Closes #12