### PR TITLE
feat: Add contextual logger support with a `With` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,33 @@ if err != nil {
 ```
 If `Fatalf` is called, after printing the above log, the program will exit with status code 1.
 
+### Adding Context with the `With` Method (Child Loggers)
+
+You can create a contextual logger (or "child logger") that carries a predefined set of key-value pairs. This is extremely useful for request-scoped logging, as you don't need to repeat fields like a `requestID` in every log call.
+
+```go
+var logger = harelog.New() // Your base logger
+
+func handleRequest(w http.ResponseWriter, r *http.Request) {
+    // Create a new child logger with context for this specific request.
+    // The base logger is not modified.
+    reqLogger := logger.With("requestID", "abc-123", "remoteAddr", r.RemoteAddr)
+
+    reqLogger.Infof("request received")
+    // ... do some work ...
+    reqLogger.Infow("user authenticated", "userID", "user-456")
+}
+```
+
+**Example output:**
+
+The `requestID` and `remoteAddr` fields are automatically added to all logs from `reqLogger`.
+
+```json
+{"message":"request received","severity":"INFO","requestID":"abc-123","remoteAddr":"127.0.0.1:12345",...}
+{"message":"user authenticated","severity":"INFO","userID":"user-456","requestID":"abc-123","remoteAddr":"127.0.0.1:12345",...}
+```
+
 ### Formatted Logging (`...f` series)
 
 Outputs simple logs using a `printf`-style format.


### PR DESCRIPTION
### Summary

This pull request introduces support for "contextual loggers" (or child loggers) by adding a `With` method. This is a significant feature that allows users to create logger instances pre-populated with key-value pairs (e.g., `requestID`, `service`), which are then automatically included in all subsequent log entries from that logger.

This greatly improves usability for request-scoped logging and eliminates the need to repeat common contextual fields in every logging call.

### Implementation Details

- **New `With` Method:**
  - An immutable `With(kvs ...interface{}) *Logger` method has been added. It returns a new logger instance with the specified context, leaving the original logger unchanged.

- **Error Handling Strategy:**
  - The `With` method employs a "Fail Early" strategy. It will **panic** if provided with an incorrect number of arguments or a non-string key, as this is considered a programmer error that should be caught during development.
  - This contrasts with `...w` methods, which will continue execution and log an internal error, as they may handle dynamic runtime data.

- **Contextual Fields in Logger:**
  - The `Logger` struct has been extended with a `payloadFields map[string]interface{}` to store the context.

- **Unified Key-Value Processing:**
  - A new private helper method, `(*logEntry).applyKVs`, has been introduced to centralize the logic for processing key-value pairs.
  - This ensures that both the logger's context (`payloadFields`) and the arguments passed to `...w` methods are processed with the exact same rules, including the special handling for keys like `error`, `httpRequest`, and `sourceLocation`. This fixes a critical bug where special keys in the context were not being processed correctly.

- **Comprehensive Tests:**
  - A new `TestWithMethod` has been added to `harelog_test.go` to thoroughly test the new functionality, including context propagation, immutability, key overriding, panic conditions, and the correct handling of special keys.

### Review Request

- Please review the API design, particularly the distinction between the "Fail Early" panic behavior in `With` and the more robust error logging in `...w` methods.
- Feedback on the implementation of the `applyKVs` helper for unifying context processing would be appreciated.

Closes #15 
