### PR TITLE
feat: 子ロガーとcontext.Context連携機能を追加

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -4,6 +4,7 @@
 package harelog
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -180,8 +181,11 @@ type Logger struct {
 	logLevel      logLevelValue
 	prefix        string
 	correlationID string
+	projectID     string
 
 	payload map[string]interface{}
+
+	traceContextKey interface{}
 
 	formatter Formatter
 }
@@ -197,6 +201,7 @@ func New(opts ...Option) *Logger {
 		logLevel:      logLevelValueInfo,
 		prefix:        "",
 		correlationID: "",
+		projectID:     "",
 		labels:        make(map[string]string),
 		payload:       make(map[string]interface{}),
 		formatter:     NewJSONFormatter(),
@@ -217,16 +222,18 @@ func Clone() *Logger {
 // Clone creates a new copy of the logger.
 func (l *Logger) Clone() *Logger {
 	newLogger := &Logger{
-		out:           l.out,
-		trace:         l.trace,
-		spanId:        l.spanId,
-		traceSampled:  l.traceSampled,
-		logLevel:      l.logLevel,
-		prefix:        l.prefix,
-		correlationID: l.correlationID,
-		labels:        make(map[string]string),
-		payload:       make(map[string]interface{}),
-		formatter:     l.formatter,
+		out:             l.out,
+		trace:           l.trace,
+		spanId:          l.spanId,
+		traceSampled:    l.traceSampled,
+		logLevel:        l.logLevel,
+		prefix:          l.prefix,
+		correlationID:   l.correlationID,
+		projectID:       l.projectID,
+		labels:          make(map[string]string),
+		payload:         make(map[string]interface{}),
+		traceContextKey: l.traceContextKey,
+		formatter:       l.formatter,
 	}
 
 	for k, v := range l.labels {
@@ -240,160 +247,286 @@ func (l *Logger) Clone() *Logger {
 	return newLogger
 }
 
-// Debugf logs a formatted message at the Debug level.
-func (l *Logger) Debugf(format string, v ...interface{}) {
+// DebugfCtx logs a formatted message at the Debug level.
+// It extracts values from the provided context, such as Google Cloud Trace identifiers,
+// and includes them in the log entry.
+func (l *Logger) DebugfCtx(ctx context.Context, format string, v ...interface{}) {
 	if !l.IsDebugEnabled() {
 		return
 	}
 
-	l.print(l.createEntryf(LogLevelDebug, format, v...))
+	l.print(l.createEntry(ctx, LogLevelDebug, fmt.Sprintf(format, v...)))
+}
+
+// InfofCtx logs a formatted message at the Info level.
+// It extracts values from the provided context, such as Google Cloud Trace identifiers,
+// and includes them in the log entry.
+func (l *Logger) InfofCtx(ctx context.Context, format string, v ...interface{}) {
+	if !l.IsInfoEnabled() {
+		return
+	}
+
+	l.print(l.createEntry(ctx, LogLevelInfo, fmt.Sprintf(format, v...)))
+}
+
+// WarnfCtx logs a formatted message at the Warn level.
+// It extracts values from the provided context, such as Google Cloud Trace identifiers,
+// and includes them in the log entry.
+func (l *Logger) WarnfCtx(ctx context.Context, format string, v ...interface{}) {
+	if !l.IsWarnEnabled() {
+		return
+	}
+
+	l.print(l.createEntry(ctx, LogLevelWarn, fmt.Sprintf(format, v...)))
+}
+
+// ErrorfCtx logs a formatted message at the Error level.
+// It extracts values from the provided context, such as Google Cloud Trace identifiers,
+// and includes them in the log entry.
+func (l *Logger) ErrorfCtx(ctx context.Context, format string, v ...interface{}) {
+	if !l.IsErrorEnabled() {
+		return
+	}
+
+	l.print(l.createEntry(ctx, LogLevelError, fmt.Sprintf(format, v...)))
+}
+
+// CriticalfCtx logs a formatted message at the Critical level.
+// It extracts values from the provided context, such as Google Cloud Trace identifiers,
+// and includes them in the log entry.
+func (l *Logger) CriticalfCtx(ctx context.Context, format string, v ...interface{}) {
+	if !l.IsCriticalEnabled() {
+		return
+	}
+
+	l.print(l.createEntry(ctx, LogLevelCritical, fmt.Sprintf(format, v...)))
+}
+
+// PrintfCtx logs a formatted message at the Info level, like log.Printf.
+// It extracts values from the provided context, such as Google Cloud Trace identifiers,
+// and includes them in the log entry.
+func (l *Logger) PrintfCtx(ctx context.Context, format string, v ...interface{}) {
+	l.InfofCtx(ctx, format, v...)
+}
+
+// PrintCtx logs its arguments at the Info level, like log.Print.
+// It extracts values from the provided context, such as Google Cloud Trace identifiers,
+// and includes them in the log entry.
+func (l *Logger) PrintCtx(ctx context.Context, v ...interface{}) {
+	if !l.IsInfoEnabled() {
+		return
+	}
+
+	l.print(l.createEntry(ctx, LogLevelInfo, sprintMessage(v...)))
+}
+
+// PrintlnCtx logs its arguments at the Info level, like log.Println.
+// It extracts values from the provided context, such as Google Cloud Trace identifiers,
+// and includes them in the log entry.
+func (l *Logger) PrintlnCtx(ctx context.Context, v ...interface{}) {
+	if !l.IsInfoEnabled() {
+		return
+	}
+
+	l.print(l.createEntry(ctx, LogLevelInfo, sprintlnMessage(v...)))
+}
+
+// FatalCtxf logs a formatted message at the Critical level and then calls os.Exit(1).
+// It extracts values from the provided context, such as Google Cloud Trace identifiers,
+// and includes them in the log entry.
+func (l *Logger) FatalfCtx(ctx context.Context, format string, v ...interface{}) {
+	if l.IsCriticalEnabled() {
+		l.print(l.createEntry(ctx, LogLevelCritical, fmt.Sprintf(format, v...)))
+	}
+
+	osExit(1)
+}
+
+// FatalCtx logs its arguments at the Critical level and then calls os.Exit(1).
+// It extracts values from the provided context, such as Google Cloud Trace identifiers,
+// and includes them in the log entry.
+func (l *Logger) FatalCtx(ctx context.Context, v ...interface{}) {
+	if l.IsCriticalEnabled() {
+		l.print(l.createEntry(ctx, LogLevelCritical, sprintMessage(v...)))
+	}
+
+	osExit(1)
+}
+
+// FatallnCtx logs its arguments at the Critical level and then calls os.Exit(1).
+// It extracts values from the provided context, such as Google Cloud Trace identifiers,
+// and includes them in the log entry.
+func (l *Logger) FatallnCtx(ctx context.Context, v ...interface{}) {
+	if l.IsCriticalEnabled() {
+		l.print(l.createEntry(ctx, LogLevelCritical, sprintlnMessage(v...)))
+	}
+
+	osExit(1)
+}
+
+// DebugwCtx logs a formatted message at the Debug level.
+// It extracts values from the provided context, such as Google Cloud Trace identifiers,
+// and includes them in the log entry.
+func (l *Logger) DebugwCtx(ctx context.Context, msg string, kvs ...interface{}) {
+	if !l.IsDebugEnabled() {
+		return
+	}
+
+	l.print(l.createEntry(ctx, LogLevelDebug, msg, kvs...))
+}
+
+// InfowCtx logs a formatted message at the Info level.
+// It extracts values from the provided context, such as Google Cloud Trace identifiers,
+// and includes them in the log entry.
+func (l *Logger) InfowCtx(ctx context.Context, msg string, kvs ...interface{}) {
+	if !l.IsInfoEnabled() {
+		return
+	}
+
+	l.print(l.createEntry(ctx, LogLevelInfo, msg, kvs...))
+}
+
+// WarnwCtx logs a formatted message at the Warn level.
+// It extracts values from the provided context, such as Google Cloud Trace identifiers,
+// and includes them in the log entry.
+func (l *Logger) WarnwCtx(ctx context.Context, msg string, kvs ...interface{}) {
+	if !l.IsWarnEnabled() {
+		return
+	}
+
+	l.print(l.createEntry(ctx, LogLevelWarn, msg, kvs...))
+}
+
+// ErrorwCtx logs a formatted message at the Error level.
+// It extracts values from the provided context, such as Google Cloud Trace identifiers,
+// and includes them in the log entry.
+func (l *Logger) ErrorwCtx(ctx context.Context, msg string, kvs ...interface{}) {
+	if !l.IsErrorEnabled() {
+		return
+	}
+
+	l.print(l.createEntry(ctx, LogLevelError, msg, kvs...))
+}
+
+// CriticalwCtx logs a formatted message at the Critical level.
+// It extracts values from the provided context, such as Google Cloud Trace identifiers,
+// and includes them in the log entry.
+func (l *Logger) CriticalwCtx(ctx context.Context, msg string, kvs ...interface{}) {
+	if !l.IsCriticalEnabled() {
+		return
+	}
+
+	l.print(l.createEntry(ctx, LogLevelCritical, msg, kvs...))
+}
+
+// FatalwCtx logs a message with structured key-value pairs at the Critical level
+// and then calls os.Exit(1).
+// It extracts values from the provided context, such as Google Cloud Trace identifiers,
+// and includes them in the log entry.
+func (l *Logger) FatalwCtx(ctx context.Context, msg string, kvs ...interface{}) {
+	if !l.IsCriticalEnabled() {
+		return
+	}
+
+	l.print(l.createEntry(ctx, LogLevelCritical, msg, kvs...))
+
+	osExit(1)
+}
+
+// Debugf logs a formatted message at the Debug level.
+func (l *Logger) Debugf(format string, v ...interface{}) {
+	l.DebugfCtx(nil, format, v...)
 }
 
 // Infof logs a formatted message at the Info level.
 func (l *Logger) Infof(format string, v ...interface{}) {
-	if !l.IsInfoEnabled() {
-		return
-	}
-
-	l.print(l.createEntryf(LogLevelInfo, format, v...))
+	l.InfofCtx(nil, format, v...)
 }
 
 // Warnf logs a formatted message at the Warn level.
 func (l *Logger) Warnf(format string, v ...interface{}) {
-	if !l.IsWarnEnabled() {
-		return
-	}
-
-	l.print(l.createEntryf(LogLevelWarn, format, v...))
+	l.WarnfCtx(nil, format, v...)
 }
 
 // Errorf logs a formatted message at the Error level.
 func (l *Logger) Errorf(format string, v ...interface{}) {
-	if !l.IsErrorEnabled() {
-		return
-	}
-
-	l.print(l.createEntryf(LogLevelError, format, v...))
+	l.ErrorfCtx(nil, format, v...)
 }
 
 // Criticalf logs a formatted message at the Critical level.
 func (l *Logger) Criticalf(format string, v ...interface{}) {
-	if !l.IsCriticalEnabled() {
-		return
-	}
-
-	l.print(l.createEntryf(LogLevelCritical, format, v...))
+	l.CriticalfCtx(nil, format, v...)
 }
 
 // Printf logs a formatted message at the Info level, like log.Printf.
 func (l *Logger) Printf(format string, v ...interface{}) {
-	l.Infof(format, v...)
+	l.PrintfCtx(nil, format, v...)
 }
 
 // Print logs its arguments at the Info level, like log.Print.
 func (l *Logger) Print(v ...interface{}) {
-	if !l.IsInfoEnabled() {
-		return
-	}
-
-	l.print(l.createEntry(LogLevelInfo, sprintMessage(v...)))
+	l.PrintCtx(nil, v...)
 }
 
 // Println logs its arguments at the Info level, like log.Println.
 func (l *Logger) Println(v ...interface{}) {
-	if !l.IsInfoEnabled() {
-		return
-	}
-
-	l.print(l.createEntry(LogLevelInfo, sprintlnMessage(v...)))
+	l.PrintlnCtx(nil, v...)
 }
 
 // Fatalf logs a formatted message at the Critical level and then calls os.Exit(1).
 func (l *Logger) Fatalf(format string, v ...interface{}) {
-	if l.IsCriticalEnabled() {
-		l.print(l.createEntryf(LogLevelCritical, format, v...))
-	}
-
-	osExit(1)
+	l.FatalfCtx(nil, format, v...)
 }
 
 // Fatal logs its arguments at the Critical level and then calls os.Exit(1).
 func (l *Logger) Fatal(v ...interface{}) {
-	if l.IsCriticalEnabled() {
-		l.print(l.createEntry(LogLevelCritical, sprintMessage(v...)))
-	}
-
-	osExit(1)
+	l.FatalCtx(nil, v...)
 }
 
 // Fatalln logs its arguments at the Critical level and then calls os.Exit(1).
 func (l *Logger) Fatalln(v ...interface{}) {
-	if l.IsCriticalEnabled() {
-		l.print(l.createEntry(LogLevelCritical, sprintlnMessage(v...)))
-	}
-
-	osExit(1)
+	l.FatallnCtx(nil, v...)
 }
 
 // Debugw logs a message at the Debug level with structured key-value pairs.
 func (l *Logger) Debugw(msg string, kvs ...interface{}) {
-	if !l.IsDebugEnabled() {
-		return
-	}
-
-	l.print(l.createEntryw(LogLevelDebug, msg, kvs...))
+	l.DebugwCtx(nil, msg, kvs...)
 }
 
 // Infow logs a message at the Info level with structured key-value pairs.
 func (l *Logger) Infow(msg string, kvs ...interface{}) {
-	if !l.IsInfoEnabled() {
-		return
-	}
-
-	l.print(l.createEntryw(LogLevelInfo, msg, kvs...))
+	l.InfowCtx(nil, msg, kvs...)
 }
 
 // Warnw logs a message at the Warn level with structured key-value pairs.
 func (l *Logger) Warnw(msg string, kvs ...interface{}) {
-	if !l.IsWarnEnabled() {
-		return
-	}
-
-	l.print(l.createEntryw(LogLevelWarn, msg, kvs...))
+	l.WarnwCtx(nil, msg, kvs...)
 }
 
 // Errorw logs a message at the Error level with structured key-value pairs.
 func (l *Logger) Errorw(msg string, kvs ...interface{}) {
-	if !l.IsErrorEnabled() {
-		return
-	}
-
-	l.print(l.createEntryw(LogLevelError, msg, kvs...))
+	l.ErrorwCtx(nil, msg, kvs...)
 }
 
 // Criticalw logs a message at the Critical level with structured key-value pairs.
 func (l *Logger) Criticalw(msg string, kvs ...interface{}) {
-	if !l.IsCriticalEnabled() {
-		return
-	}
-
-	l.print(l.createEntryw(LogLevelCritical, msg, kvs...))
+	l.CriticalwCtx(nil, msg, kvs...)
 }
 
 // Fatalw logs a message with structured key-value pairs at the Critical level
 // and then calls os.Exit(1).
 func (l *Logger) Fatalw(msg string, kvs ...interface{}) {
-	if !l.IsCriticalEnabled() {
-		return
-	}
-
-	l.print(l.createEntryw(LogLevelCritical, msg, kvs...))
-
-	osExit(1)
+	l.FatalwCtx(nil, msg, kvs...)
 }
 
 // createEntry creates a logEntry with a pre-formatted message.
-func (l *Logger) createEntry(level logLevel, msg string) *logEntry {
+// func (l *Logger) createEntry(level logLevel, msg string) *logEntry {
+
+// createEntry is the single, central helper for creating log entries.
+// It accepts a context (which can be nil) and correctly applies values with the
+// precedence: method args > logger context > context.Context.
+func (l *Logger) createEntry(ctx context.Context, level logLevel, msg string, kvs ...interface{}) *logEntry {
+	// 1. Create the base entry.
 	e := &logEntry{
 		Severity:      string(level),
 		Message:       l.prefix + msg,
@@ -406,7 +539,23 @@ func (l *Logger) createEntry(level logLevel, msg string) *logEntry {
 		Payload:       make(map[string]interface{}, len(l.payload)),
 	}
 
-	// Convert logger's context map to a slice and apply it.
+	// 2. Apply values from context.Context (lowest precedence).
+	if ctx != nil && l.projectID != "" && l.traceContextKey != nil {
+		if traceHeader, ok := ctx.Value(l.traceContextKey).(string); ok {
+			parts := strings.Split(traceHeader, "/")
+
+			if len(parts) > 0 && e.Trace == "" {
+				e.Trace = fmt.Sprintf("projects/%s/traces/%s", l.projectID, parts[0])
+			}
+
+			if len(parts) > 1 && e.SpanID == "" {
+				spanParts := strings.Split(parts[1], ";")
+				e.SpanID = spanParts[0]
+			}
+		}
+	}
+
+	// 3. Apply contextual fields from the logger (With method).
 	if len(l.payload) > 0 {
 		contextKVs := make([]interface{}, 0, len(l.payload)*2)
 
@@ -417,18 +566,10 @@ func (l *Logger) createEntry(level logLevel, msg string) *logEntry {
 		e.applyKVs(contextKVs...)
 	}
 
-	return e
-}
-
-// createEntryf creates a logEntry by formatting a message.
-func (l *Logger) createEntryf(level logLevel, format string, v ...interface{}) *logEntry {
-	return l.createEntry(level, fmt.Sprintf(format, v...))
-}
-
-// createEntryw creates a logEntry from the logger's context and the provided arguments.
-func (l *Logger) createEntryw(severity logLevel, msg string, kvs ...interface{}) *logEntry {
-	e := l.createEntry(severity, msg) // Creates entry with context pre-filled and processed.
-	e.applyKVs(kvs...)                // Apply and overwrite with local KVs.
+	// 4. Apply key-value pairs from the specific log call (highest precedence).
+	if len(kvs) > 0 {
+		e.applyKVs(kvs...)
+	}
 
 	return e
 }
@@ -675,6 +816,177 @@ func IsCriticalEnabled() bool {
 	return std.IsCriticalEnabled()
 }
 
+// DebugfCtx logs a formatted message at the Debug level using the default logger.
+// It extracts values from the provided context, such as Google Cloud Trace identifiers,
+// and includes them in the log entry.
+func DebugfCtx(ctx context.Context, format string, v ...interface{}) {
+	stdMutex.RLock()
+	defer stdMutex.RUnlock()
+
+	std.DebugfCtx(ctx, format, v...)
+}
+
+// InfofCtx logs a formatted message at the Info level using the default logger.
+// It extracts values from the provided context, such as Google Cloud Trace identifiers,
+// and includes them in the log entry.
+func InfofCtx(ctx context.Context, format string, v ...interface{}) {
+	stdMutex.RLock()
+	defer stdMutex.RUnlock()
+
+	std.InfofCtx(ctx, format, v...)
+}
+
+// WarnfCtx logs a formatted message at the Warn level using the default logger.
+// It extracts values from the provided context, such as Google Cloud Trace identifiers,
+// and includes them in the log entry.
+func WarnfCtx(ctx context.Context, format string, v ...interface{}) {
+	stdMutex.RLock()
+	defer stdMutex.RUnlock()
+
+	std.WarnfCtx(ctx, format, v...)
+}
+
+// ErrorfCtx logs a formatted message at the Error level using the default logger.
+// It extracts values from the provided context, such as Google Cloud Trace identifiers,
+// and includes them in the log entry.
+func ErrorfCtx(ctx context.Context, format string, v ...interface{}) {
+	stdMutex.RLock()
+	defer stdMutex.RUnlock()
+
+	std.ErrorfCtx(ctx, format, v...)
+}
+
+// CriticalfCtx logs a formatted message at the Critical level using the default logger.
+// It extracts values from the provided context, such as Google Cloud Trace identifiers,
+// and includes them in the log entry.
+func CriticalfCtx(ctx context.Context, format string, v ...interface{}) {
+	stdMutex.RLock()
+	defer stdMutex.RUnlock()
+
+	std.CriticalfCtx(ctx, format, v...)
+}
+
+// PrintfCtx logs a formatted message at the Info level using the default logger.
+// It extracts values from the provided context, such as Google Cloud Trace identifiers,
+// and includes them in the log entry.
+func PrintfCtx(ctx context.Context, format string, v ...interface{}) {
+	stdMutex.RLock()
+	defer stdMutex.RUnlock()
+
+	std.PrintfCtx(ctx, format, v...)
+}
+
+// PrintCtx logs its arguments at the Info level using the default logger.
+// It extracts values from the provided context, such as Google Cloud Trace identifiers,
+// and includes them in the log entry.
+func PrintCtx(ctx context.Context, v ...interface{}) {
+	stdMutex.RLock()
+	defer stdMutex.RUnlock()
+
+	std.PrintCtx(ctx, v...)
+}
+
+// PrintlnCtx logs its arguments at the Info level using the default logger.
+// It extracts values from the provided context, such as Google Cloud Trace identifiers,
+// and includes them in the log entry.
+func PrintlnCtx(ctx context.Context, v ...interface{}) {
+	stdMutex.RLock()
+	defer stdMutex.RUnlock()
+
+	std.PrintlnCtx(ctx, v...)
+}
+
+// FatalfCtx logs a formatted message at the Critical level and then calls os.Exit(1).
+// It extracts values from the provided context, such as Google Cloud Trace identifiers,
+// and includes them in the log entry.
+func FatalfCtx(ctx context.Context, format string, v ...interface{}) {
+	stdMutex.RLock()
+	defer stdMutex.RUnlock()
+
+	std.FatalfCtx(ctx, format, v...)
+}
+
+// FatalCtx logs its arguments at the Critical level and then calls os.Exit(1).
+// It extracts values from the provided context, such as Google Cloud Trace identifiers,
+// and includes them in the log entry.
+func FatalCtx(ctx context.Context, v ...interface{}) {
+	stdMutex.RLock()
+	defer stdMutex.RUnlock()
+
+	std.FatalCtx(ctx, v...)
+}
+
+// FatallnCtx logs its arguments at the Critical level and then calls os.Exit(1).
+// It extracts values from the provided context, such as Google Cloud Trace identifiers,
+// and includes them in the log entry.
+func FatallnCtx(ctx context.Context, v ...interface{}) {
+	stdMutex.RLock()
+	defer stdMutex.RUnlock()
+
+	std.FatallnCtx(ctx, v...)
+}
+
+// DebugwCtx logs a message at the Debug level using the default logger.
+// It extracts values from the provided context, such as Google Cloud Trace identifiers,
+// and includes them in the log entry.
+func DebugwCtx(ctx context.Context, msg string, kvs ...interface{}) {
+	stdMutex.RLock()
+	defer stdMutex.RUnlock()
+
+	std.DebugwCtx(ctx, msg, kvs...)
+}
+
+// InfowCtx logs a message at the Info level using the default logger.
+// It extracts values from the provided context, such as Google Cloud Trace identifiers,
+// and includes them in the log entry.
+func InfowCtx(ctx context.Context, msg string, kvs ...interface{}) {
+	stdMutex.RLock()
+	defer stdMutex.RUnlock()
+
+	std.InfowCtx(ctx, msg, kvs...)
+}
+
+// WarnwCtx logs a message at the Warn level using the default logger.
+// It extracts values from the provided context, such as Google Cloud Trace identifiers,
+// and includes them in the log entry.
+func WarnwCtx(ctx context.Context, msg string, kvs ...interface{}) {
+	stdMutex.RLock()
+	defer stdMutex.RUnlock()
+
+	std.WarnwCtx(ctx, msg, kvs...)
+}
+
+// ErrorwCtx logs a message at the Error level using the default logger.
+// It extracts values from the provided context, such as Google Cloud Trace identifiers,
+// and includes them in the log entry.
+func ErrorwCtx(ctx context.Context, msg string, kvs ...interface{}) {
+	stdMutex.RLock()
+	defer stdMutex.RUnlock()
+
+	std.ErrorwCtx(ctx, msg, kvs...)
+}
+
+// CriticalwCtx logs a message at the Critical level using the default logger.
+// It extracts values from the provided context, such as Google Cloud Trace identifiers,
+// and includes them in the log entry.
+func CriticalwCtx(ctx context.Context, msg string, kvs ...interface{}) {
+	stdMutex.RLock()
+	defer stdMutex.RUnlock()
+
+	std.CriticalwCtx(ctx, msg, kvs...)
+}
+
+// FatalwCtx logs a message with structured key-value pairs at the Critical level
+// using the default logger and then calls os.Exit(1).
+// It extracts values from the provided context, such as Google Cloud Trace identifiers,
+// and includes them in the log entry.
+func FatalwCtx(ctx context.Context, msg string, kvs ...interface{}) {
+	stdMutex.RLock()
+	defer stdMutex.RUnlock()
+
+	std.FatalwCtx(ctx, msg, kvs...)
+}
+
 // Debugf logs a formatted message at the Debug level using the default logger.
 func Debugf(format string, v ...interface{}) {
 	stdMutex.RLock()
@@ -874,5 +1186,19 @@ func WithOutput(w io.Writer) Option {
 		if w != nil {
 			l.out = w
 		}
+	}
+}
+
+// WithProjectID sets the Google Cloud Project ID to be used for formatting trace identifiers.
+func WithProjectID(id string) Option {
+	return func(l *Logger) {
+		l.projectID = id
+	}
+}
+
+// WithTraceContextKey sets the key used to extract Google Cloud Trace data from a context.Context.
+func WithTraceContextKey(key interface{}) Option {
+	return func(l *Logger) {
+		l.traceContextKey = key
 	}
 }

--- a/logger.go
+++ b/logger.go
@@ -435,88 +435,88 @@ func (l *Logger) FatalwCtx(ctx context.Context, msg string, kvs ...interface{}) 
 
 // Debugf logs a formatted message at the Debug level.
 func (l *Logger) Debugf(format string, v ...interface{}) {
-	l.DebugfCtx(nil, format, v...)
+	l.DebugfCtx(context.Background(), format, v...)
 }
 
 // Infof logs a formatted message at the Info level.
 func (l *Logger) Infof(format string, v ...interface{}) {
-	l.InfofCtx(nil, format, v...)
+	l.InfofCtx(context.Background(), format, v...)
 }
 
 // Warnf logs a formatted message at the Warn level.
 func (l *Logger) Warnf(format string, v ...interface{}) {
-	l.WarnfCtx(nil, format, v...)
+	l.WarnfCtx(context.Background(), format, v...)
 }
 
 // Errorf logs a formatted message at the Error level.
 func (l *Logger) Errorf(format string, v ...interface{}) {
-	l.ErrorfCtx(nil, format, v...)
+	l.ErrorfCtx(context.Background(), format, v...)
 }
 
 // Criticalf logs a formatted message at the Critical level.
 func (l *Logger) Criticalf(format string, v ...interface{}) {
-	l.CriticalfCtx(nil, format, v...)
+	l.CriticalfCtx(context.Background(), format, v...)
 }
 
 // Printf logs a formatted message at the Info level, like log.Printf.
 func (l *Logger) Printf(format string, v ...interface{}) {
-	l.PrintfCtx(nil, format, v...)
+	l.PrintfCtx(context.Background(), format, v...)
 }
 
 // Print logs its arguments at the Info level, like log.Print.
 func (l *Logger) Print(v ...interface{}) {
-	l.PrintCtx(nil, v...)
+	l.PrintCtx(context.Background(), v...)
 }
 
 // Println logs its arguments at the Info level, like log.Println.
 func (l *Logger) Println(v ...interface{}) {
-	l.PrintlnCtx(nil, v...)
+	l.PrintlnCtx(context.Background(), v...)
 }
 
 // Fatalf logs a formatted message at the Critical level and then calls os.Exit(1).
 func (l *Logger) Fatalf(format string, v ...interface{}) {
-	l.FatalfCtx(nil, format, v...)
+	l.FatalfCtx(context.Background(), format, v...)
 }
 
 // Fatal logs its arguments at the Critical level and then calls os.Exit(1).
 func (l *Logger) Fatal(v ...interface{}) {
-	l.FatalCtx(nil, v...)
+	l.FatalCtx(context.Background(), v...)
 }
 
 // Fatalln logs its arguments at the Critical level and then calls os.Exit(1).
 func (l *Logger) Fatalln(v ...interface{}) {
-	l.FatallnCtx(nil, v...)
+	l.FatallnCtx(context.Background(), v...)
 }
 
 // Debugw logs a message at the Debug level with structured key-value pairs.
 func (l *Logger) Debugw(msg string, kvs ...interface{}) {
-	l.DebugwCtx(nil, msg, kvs...)
+	l.DebugwCtx(context.Background(), msg, kvs...)
 }
 
 // Infow logs a message at the Info level with structured key-value pairs.
 func (l *Logger) Infow(msg string, kvs ...interface{}) {
-	l.InfowCtx(nil, msg, kvs...)
+	l.InfowCtx(context.Background(), msg, kvs...)
 }
 
 // Warnw logs a message at the Warn level with structured key-value pairs.
 func (l *Logger) Warnw(msg string, kvs ...interface{}) {
-	l.WarnwCtx(nil, msg, kvs...)
+	l.WarnwCtx(context.Background(), msg, kvs...)
 }
 
 // Errorw logs a message at the Error level with structured key-value pairs.
 func (l *Logger) Errorw(msg string, kvs ...interface{}) {
-	l.ErrorwCtx(nil, msg, kvs...)
+	l.ErrorwCtx(context.Background(), msg, kvs...)
 }
 
 // Criticalw logs a message at the Critical level with structured key-value pairs.
 func (l *Logger) Criticalw(msg string, kvs ...interface{}) {
-	l.CriticalwCtx(nil, msg, kvs...)
+	l.CriticalwCtx(context.Background(), msg, kvs...)
 }
 
 // Fatalw logs a message with structured key-value pairs at the Critical level
 // and then calls os.Exit(1).
 func (l *Logger) Fatalw(msg string, kvs ...interface{}) {
-	l.FatalwCtx(nil, msg, kvs...)
+	l.FatalwCtx(context.Background(), msg, kvs...)
 }
 
 // createEntry creates a logEntry with a pre-formatted message.


### PR DESCRIPTION
### 概要

`slog`や`zap`といったモダンなロギングライブラリに倣い、リクエストスコープのロギングを大幅に改善するため、2つの主要な機能を追加します。

1.  **子ロガー機能 (`With`メソッド):** リクエストIDなどのコンテキスト情報を保持する「子ロガー」を生成する機能です。
2.  **`context.Context`連携 (`...Ctx`メソッド):** `context.Context`からトレース情報などを自動で抽出する機能です。

これらの機能により、毎回同じ情報を手動でログに追加する手間が省け、コードがよりクリーンで堅牢になります。

### 変更内容

- **子ロガー機能 (`With`メソッド) の実装:**
  - `With(kvs ...interface{}) *Logger`メソッドを実装しました。これは、元のロガーを変更せず、新しいコンテキストを持つコピーを返します（イミュータブル）。
  - 不正な引数（奇数個、非文字列キー）が渡された場合は、プログラマーのバグとして即座に`panic`し、早期に問題を検知できるようにしました。

- **`context.Context`連携 (`...Ctx`メソッド) の実装:**
  - 全てのログ出力メソッドに、`context.Context`を第一引数に取る`...Ctx`版を追加しました (`InfofCtx`, `InfowCtx`など)。
  - 既存のメソッドは、`nil`コンテキストで`...Ctx`版を呼び出すラッパーとして再実装し、コードの重複を排除しました。

- **コンテキスト抽出と設定:**
  - `New()`のオプションとして`WithProjectID`と`WithTraceContextKey`を追加し、利用者がGoogle Cloud Trace情報の抽出方法を柔軟に設定できるようにしました。

- **内部リファクタリング:**
  - ログエントリの生成ロジックを、新しい中央ヘルパー`createEntry`に集約しました。
  - このヘルパーは、**`Context` < `With`のコンテキスト < `...w`の引数**、という正しい優先順位で値を適用することを保証します。
  
Closes #17 