### PR TITLE
feat: 環境変数によるデフォルトログレベルの設定機能を追加

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -61,6 +61,29 @@ var levelMap = map[logLevel]logLevelValue{
 	LogLevelAll:      logLevelValueAll,
 }
 
+func init() {
+	setupLogLevelFromEnv()
+}
+
+// setupLogLevelFromEnv reads the HARELOG_LEVEL environment variable and
+// configures the default logger's log level accordingly.
+func setupLogLevelFromEnv() {
+	levelStr := os.Getenv("HARELOG_LEVEL")
+
+	if levelStr == "" {
+		return
+	}
+
+	level, err := ParseLogLevel(levelStr)
+	if err != nil {
+		log.Printf("harelog: invalid HARELOG_LEVEL value %q, using default level", levelStr)
+
+		return
+	}
+
+	SetDefaultLogLevel(level)
+}
+
 // ParseLogLevel parses a string into a LogLevel.
 // It is case-insensitive. It returns an error if the input string is not a valid log level.
 func ParseLogLevel(levelStr string) (logLevel, error) {


### PR DESCRIPTION
### 概要

アプリケーションを再コンパイル・再デプロイすることなく、環境に応じてログの詳しさを動的に変更できるようにするため、環境変数 `HARELOG_LEVEL` を通じてデフォルトのログレベルを設定する機能を追加しました。

これにより、開発環境では `DEBUG` レベルで詳細なログを、本番環境では `INFO` レベルで通常のログを出力する、といった運用が非常に簡単になります。

### 変更内容

- **`init()` 関数の実装:**
  - `harelog`パッケージの初期化時に`init()`関数が実行され、環境変数 `HARELOG_LEVEL` を自動で読み取ります。

- **環境変数の解析と設定:**
  - 環境変数が設定されている場合、既存の`ParseLogLevel`関数を使って値を検証します。
  - 検証が成功した場合のみ、`SetDefaultLogLevel`を呼び出して、パッケージレベルのデフォルトロガー (`std`) のログレベルを設定します。

- **堅牢なフォールバック処理:**
  - 環境変数が設定されていない場合や、値が無効な文字列（例: "INVALID_LEVEL"）だった場合は、警告を標準エラー出力に表示し、既存のデフォルトログレベル（`INFO`）を維持します。これにより、設定ミスによってアプリケーションが起動しなくなることを防ぎます。

- **テストの追加:**
  - `t.Setenv`（Go 1.17+）を利用して、環境変数が設定されている場合、されていない場合、無効な値が設定されている場合の3つのシナリオを検証するユニットテストを追加しました。
  - テスト容易性を向上させるため、実際のロジックは`init()`から`setupLogLevelFromEnv`ヘルパー関数に分離しました。

### レビュー依頼

- 環境変数の読み取りとフォールバックのロジックに問題がないか、ご確認をお願いします。
- テストケースに不足がないか、という観点でもご意見いただけると幸いです。

Closes #19

