### PR TITLE
feat: WithLogLevelオプションの追加とAPIの堅牢性向上

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,17 @@ func handleRequest(w http.ResponseWriter, r *http.Request) {
 
 `harelog` can be configured using functional options at initialization.
 
+### Setting the Log Level
+
+You can set the initial log level when creating a new logger.
+
+```go
+// Create a logger that only outputs DEBUG level logs or higher.
+logger := harelog.New(
+    harelog.WithLogLevel(harelog.LogLevelDebug),
+)
+```
+
 ### Automatic Source Code Location
 
 For easier debugging, `harelog` can automatically log the file and line number of the log call site. This feature has a performance cost and is configurable via different modes.

--- a/logger.go
+++ b/logger.go
@@ -748,6 +748,10 @@ func (l *Logger) WithPrefix(prefix string) *Logger {
 
 // WithLogLevel returns a new logger instance with the specified log level.
 func (l *Logger) WithLogLevel(level logLevel) *Logger {
+	if _, ok := levelMap[level]; !ok {
+		panic(fmt.Sprintf("harelog: invalid log level provided to (*Logger).WithLogLevel: %q", level))
+	}
+
 	newLogger := l.Clone()
 	newLogger.logLevel = levelMap[level]
 
@@ -1303,6 +1307,10 @@ func WithProjectID(id string) Option {
 
 // WithTraceContextKey sets the key used to extract Google Cloud Trace data from a context.Context.
 func WithTraceContextKey(key interface{}) Option {
+	if key == nil {
+		panic("harelog: nil key provided to WithTraceContextKey; context keys must be non-nil")
+	}
+
 	return func(l *Logger) {
 		l.traceContextKey = key
 	}

--- a/logger.go
+++ b/logger.go
@@ -1322,3 +1322,15 @@ func WithAutoSource(mode sourceLocationMode) Option {
 		l.sourceLocationMode = mode
 	}
 }
+
+// WithLogLevel is a functional option that sets the initial log level for the logger.
+func WithLogLevel(level logLevel) Option {
+	return func(l *Logger) {
+		lv, ok := levelMap[level]
+		if !ok {
+			panic(fmt.Sprintf("harelog: invalid log level provided to WithLogLevel: %q", level))
+		}
+
+		l.logLevel = lv
+	}
+}


### PR DESCRIPTION
### 概要

`harelog`のAPIの一貫性を完成させ、設定ミスによる「静かな失敗（silent failure）」を防ぐため、2つの重要な改善を実装しました。

1.  `New()`の関数型オプションとして`WithLogLevel`を追加。
2.  `WithLogLevel`と`WithTraceContextKey`に、不正な引数が渡された場合に`panic`する安全装置を実装。

### 変更内容

#### 1. `New(WithLogLevel(...))` オプションの追加

- **機能:** `WithLogLevel(level logLevel) Option`という新しい関数型オプションを実装しました。
- **効果:** これまで2ステップ必要だったログレベルの設定が、`New()`の呼び出し時に他のオプションと一貫した形で、1ステップで完了できるようになりました。これにより、APIの直感性と一貫性が大幅に向上します。

```go
// Before:
// logger := harelog.New()
// logger = logger.WithLogLevel(harelog.LogLevelDebug)

// After:
logger := harelog.New(
    harelog.WithLogLevel(harelog.LogLevelDebug),
)
```

#### 2. "Fail Fast" 設計の導入による堅牢性の向上

- **機能:** 以下の設定用関数/メソッドに、不正な引数が渡された場合に`panic`するチェックを追加しました。
    - `WithLogLevel(level logLevel)` (関数オプション)
    - `(*Logger).WithLogLevel(level logLevel)` (メソッド)
    - `WithTraceContextKey(key interface{})` (関数オプション)
- **効果:** `ParseLogLevel`のエラーを無視した結果（空文字列）や、`nil`キーといった、プログラマーの明らかな設定ミスを、アプリケーションの起動時（開発中）に即座に検知できるようになります。これにより、「ログが出力されない」といった、本番環境での追跡が困難な問題を未然に防ぎます。

### テストとドキュメント

- `WithLogLevel`オプションが正しく機能すること、そして不正な値に対しては期待通りに`panic`することを検証するユニットテストを追加しました。
- `README.md`を更新し、新しい`WithLogLevel`オプションについて記載しました。

### レビュー依頼

- APIの一貫性が向上しているか、ご確認をお願いします。
- 「Fail Fast」として`panic`を導入した設計思想について、ご意見いただけると幸いです。

Closes #27 