### PR TITLE
fix: Clone() が traceSampled のアドレスをコピーするバグを修正

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"maps"
 	"math"
 	"os"
 	"reflect"
@@ -418,32 +419,26 @@ func (l *Logger) Clone() *Logger {
 		out:                l.out,
 		trace:              l.trace,
 		spanId:             l.spanId,
-		traceSampled:       l.traceSampled,
 		logLevel:           l.logLevel,
 		prefix:             l.prefix,
 		correlationID:      l.correlationID,
 		projectID:          l.projectID,
-		labels:             make(map[string]string),
-		payload:            make(map[string]interface{}),
 		traceContextKey:    l.traceContextKey,
 		sourceLocationMode: l.sourceLocationMode,
 		formatter:          l.formatter,
 		hooks:              l.hooks,
-		hooksByLevel:       make(map[LogLevel][]Hook),
 		hookChan:           l.hookChan,
 	}
 
-	for k, v := range l.labels {
-		newLogger.labels[k] = v
+	if l.traceSampled != nil {
+		v := *l.traceSampled
+
+		newLogger.traceSampled = &v
 	}
 
-	for k, v := range l.payload {
-		newLogger.payload[k] = v
-	}
-
-	for k, v := range l.hooksByLevel {
-		newLogger.hooksByLevel[k] = v
-	}
+	newLogger.labels = maps.Clone(l.labels)
+	newLogger.payload = maps.Clone(l.payload)
+	newLogger.hooksByLevel = maps.Clone(l.hooksByLevel)
 
 	return newLogger
 }


### PR DESCRIPTION
## 概要

`Logger.Clone()` メソッドが、`traceSampled` フィールド (`*bool`) をディープコピーせず、ポインタ（メモリアドレス）のみをコピー（浅いコピー）していました。

これにより、`WithTraceSampled(&myFlag)` でロガーを作成した後、そのロガーから `With(...)` などで派生ロガーを作成すると、すべてのロガーが外部の `myFlag` 変数のアドレスを共有していました。
その結果、外部の `myFlag` の値が変更されると、派生ロガーの値も意図せず変更されてしまい、ロガーの不変性（Immutability）が壊れるバグがありました。

このパッチは、`Clone()` が `traceSampled` の *値* をコピーし、そのコピーへの *新しいポインタ* を設定する（ディープコピー）ように修正し、不変性を保証します。

## 変更内容

### 1. `Logger.Clone()` のバグ修正 (logger.go)

- **`traceSampled` のディープコピー**:
    - `Logger.Clone()` メソッドに、`traceSampled` フィールドをディープコピーするロジックを追加しました。
    - `l.traceSampled` が `nil` でない場合、ポインタが指す先の *値* を新しい変数（`clonedVal`）にコピーします。
    - `newLogger.traceSampled` には、その `clonedVal` への *新しいポインタ* （`&clonedVal`）を設定します。
    - これにより、元のロガーと派生ロガーが `traceSampled` のポインタを共有しなくなり、不変性が保たれます。

### 2. (リファクタリング) `maps.Clone` の使用 (logger.go)

- **マップコピー処理の簡潔化**:
    - `labels`, `payload`, `hooksByLevel` の3つのマップをコピーする処理を、従来の `for` ループによる手動コピーから、Go 1.21 で追加された `maps.Clone()` を使用するように変更しました。

## レビュー依頼

- `traceSampled` のディープコピーのロジック (`if l.traceSampled != nil { ... }`) が正しいか。
- `maps.Clone` への置き換えが適切か。

Closes #53 